### PR TITLE
Added support for newer Seq64 feature (FL studio compatibility), Control Change events (fixes broken panning), and Marker/SysEx events (section/loop markers & tempo changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ If, for some reason, you wish to build this, it was built using `Visual Studio 2
 - [DryWetMidi](https://www.nuget.org/packages/Melanchall.DryWetMidi)
 - [Newtonsoft Json](https://www.newtonsoft.com/json)
 
-Additionally, `SEQ64` is not built nor included in the actual source, so you will need to download [SEQ64 v2.1](https://github.com/sauraen/seq64/releases/tag/2.1) 
+Additionally, `SEQ64` is not built nor included in the actual source, so you will need to download [SEQ64 v2.1.4](https://github.com/sauraen/seq64/releases/tag/2.1.4) 
 and either place SEQ64 in the build folder, or place the build .exe and .dll files into the SEQ64 folder.

--- a/SM64MidiCompanion/Classes/SoundBank.cs
+++ b/SM64MidiCompanion/Classes/SoundBank.cs
@@ -79,7 +79,7 @@ namespace SM64MidiCompanion.Classes
 
         public int GetInstrumentIndex(Instrument inst)
         {
-            String name = "";
+            string name = "";
 
             foreach(var i in filteredInstrumentMap)
             {
@@ -100,7 +100,7 @@ namespace SM64MidiCompanion.Classes
                 return null;
             }
 
-            String name = instrumentList[i];
+            string name = instrumentList[i];
 
             foreach(var inst in filteredInstrumentMap)
             {

--- a/SM64MidiCompanion/Classes/TrackInfo.cs
+++ b/SM64MidiCompanion/Classes/TrackInfo.cs
@@ -9,7 +9,7 @@ namespace SM64MidiCompanion.Components
 {
     class TrackInfo
     {
-        public String name = "Unnamed Track";
+        public string name = "Unnamed Track";
         public bool enabled = true;
         public int instrumentId = -1;
         public int pitchShiftId = 0;

--- a/SM64MidiCompanion/Components/TrackListView.cs
+++ b/SM64MidiCompanion/Components/TrackListView.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using System.Drawing;
 using SM64MidiCompanion.Forms;
-
+using System.ComponentModel;
 
 namespace SM64MidiCompanion.Components
 {
@@ -23,7 +23,7 @@ namespace SM64MidiCompanion.Components
 
     class TrackListView : ListView
     {
-        List<TrackInfo> tracks = new List<TrackInfo>();
+        private List<TrackInfo> tracks = new List<TrackInfo>();
 
         const int imageSize = 24;
         const int columnSize = 52;
@@ -31,6 +31,7 @@ namespace SM64MidiCompanion.Components
 
         Image checkedBox, unCheckedBox;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public List<TrackInfo> Tracks
         {
             get

--- a/SM64MidiCompanion/Form1.Designer.cs
+++ b/SM64MidiCompanion/Form1.Designer.cs
@@ -33,8 +33,7 @@ namespace SM64MidiCompanion
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("");
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("");
             this.midiInputTextBox = new System.Windows.Forms.TextBox();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.openMidiButton = new System.Windows.Forms.Button();
@@ -57,6 +56,7 @@ namespace SM64MidiCompanion
             this.soundBankToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.autoAssignChannelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.flStudioCheckbox = new System.Windows.Forms.CheckBox();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -179,7 +179,7 @@ namespace SM64MidiCompanion
             this.trackNameListView.FullRowSelect = true;
             this.trackNameListView.HideSelection = false;
             this.trackNameListView.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
-            listViewItem1});
+            listViewItem2});
             this.trackNameListView.Location = new System.Drawing.Point(347, 37);
             this.trackNameListView.Name = "trackNameListView";
             this.trackNameListView.OwnerDraw = true;
@@ -253,12 +253,24 @@ namespace SM64MidiCompanion
             this.autoAssignChannelsToolStripMenuItem.Text = "Auto Assign Channels";
             this.autoAssignChannelsToolStripMenuItem.Click += new System.EventHandler(this.autoAssignChannelsToolStripMenuItem_Click);
             // 
+            // flStudioCheckbox
+            // 
+            this.flStudioCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.flStudioCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F);
+            this.flStudioCheckbox.Location = new System.Drawing.Point(12, 351);
+            this.flStudioCheckbox.Name = "flStudioCheckbox";
+            this.flStudioCheckbox.Size = new System.Drawing.Size(314, 28);
+            this.flStudioCheckbox.TabIndex = 15;
+            this.flStudioCheckbox.Text = "FL Studio compat. mode";
+            this.flStudioCheckbox.UseVisualStyleBackColor = true;
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.ControlDarkDark;
             this.ClientSize = new System.Drawing.Size(984, 461);
+            this.Controls.Add(this.flStudioCheckbox);
             this.Controls.Add(this.saveM64Button);
             this.Controls.Add(this.outputM64TextBox);
             this.Controls.Add(this.saveErrorLabel);
@@ -305,6 +317,7 @@ namespace SM64MidiCompanion
         private System.Windows.Forms.ToolStripMenuItem soundBankToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem autoAssignChannelsToolStripMenuItem;
+        private System.Windows.Forms.CheckBox flStudioCheckbox;
     }
 }
 

--- a/SM64MidiCompanion/Form1.cs
+++ b/SM64MidiCompanion/Form1.cs
@@ -382,6 +382,10 @@ namespace SM64MidiCompanion
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.FileName = "seq64_console.exe";
             startInfo.Arguments = "--abi=sm64 --in=bin\\processed.mid --out=" + filename;
+            if (flStudioCheckbox.Checked)
+            {
+                startInfo.Arguments += " --flstudio=true";
+            }
             startInfo.UseShellExecute = false;
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardInput = false;

--- a/SM64MidiCompanion/Form1.cs
+++ b/SM64MidiCompanion/Form1.cs
@@ -330,6 +330,15 @@ namespace SM64MidiCompanion
                     {
                         continue;
                     }
+                    else if (e is ControlChangeEvent controlChangeEvent)
+                    {
+                        if (controlChangeEvent.ControlNumber != ControlName.BankSelect.AsSevenBitNumber() ||
+                            controlChangeEvent.ControlNumber != ControlName.LsbForBankSelect.AsSevenBitNumber())
+                        {
+                            newTrack.Events.Add(controlChangeEvent);
+                        }
+                        continue;
+                    }
                     else if (e is ChannelEvent channelEvent)
                     {
                         channelEvent.Channel = (FourBitNumber)trackInfo.channel;

--- a/SM64MidiCompanion/Form1.cs
+++ b/SM64MidiCompanion/Form1.cs
@@ -339,6 +339,11 @@ namespace SM64MidiCompanion
                         }
                         continue;
                     }
+                    else if (e is PitchBendEvent pitchBendEvent)
+                    {
+                        newTrack.Events.Add(pitchBendEvent);
+                        continue;
+                    }
                     else if (e is MetaEvent metaEvent)
                     {
                         if (metaEvent.EventType == MidiEventType.Marker ||

--- a/SM64MidiCompanion/Form1.cs
+++ b/SM64MidiCompanion/Form1.cs
@@ -339,6 +339,16 @@ namespace SM64MidiCompanion
                         }
                         continue;
                     }
+                    else if (e is MetaEvent metaEvent)
+                    {
+                        if (metaEvent.EventType == MidiEventType.Marker ||
+                            metaEvent.EventType == MidiEventType.NormalSysEx ||
+                            metaEvent.EventType == MidiEventType.SetTempo)
+                        {
+                            newTrack.Events.Add(metaEvent);
+                        }
+                        continue;
+                    }
                     else if (e is ChannelEvent channelEvent)
                     {
                         channelEvent.Channel = (FourBitNumber)trackInfo.channel;

--- a/SM64MidiCompanion/Form1.resx
+++ b/SM64MidiCompanion/Form1.resx
@@ -129,4 +129,7 @@
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>287, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>151</value>
+  </metadata>
 </root>


### PR DESCRIPTION
A good amount of the SM64 modding community uses FL Studio for creating/editing MIDI files.
Unfortunately if someone wanted to put (for example) loop markers in their track they wouldn't be able to, since FL Studio doesn't support MIDI text events
Seq64 now has a workaround for FL users though - using Control Change events in place of text events

I've added a toggle to enable this to the UI
The required Seq64 version has been bumped up to 2.1.4 to allow for this new behaviour

I have also added support for Channel Change events as a whole, making channel effects such as panning not get discarded in the final processed MIDI file